### PR TITLE
Add option to use PM2_HOME env var

### DIFF
--- a/libs/events.js
+++ b/libs/events.js
@@ -13,7 +13,9 @@ let events = {};
  */
 
 events.getSockPath = callback => {
-    exec('ls ~/.pm2/pub.sock', (error, stdout, stderr) => {
+    const pm2Home = process.env.PM2_HOME;
+    let command = pm2Home === undefined ? 'ls ~/.pm2/pub.sock' : `ls ${pm2Home}/pub.sock`;
+    exec(command, (error, stdout, stderr) => {
         if (error || stderr) {
             let err = error || stderr;
             return callback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-events",
-  "version": "0.1.1",
+  "version": "0.1.1-beta.1",
   "description": "catch pm2 events ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We use the PM2_HOME env var to change the location of the .pm2 folder. 
I have added the option to use this env var if it is defined for the location of pub.sock